### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,18 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show  
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
   private
 
   def items_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def show  
+    @items = Item.find(params[:id])
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: :create
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -18,7 +18,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show  
+  def show
     @items = Item.find(params[:id])
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,4 +12,7 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/day_required.rb
+++ b/app/models/day_required.rb
@@ -5,4 +5,7 @@ class DayRequired < ActiveHash::Base
     { id: 3, name: '2~3日で発送' },
     { id: 4, name: '4~7日で発送' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/fee_burden.rb
+++ b/app/models/fee_burden.rb
@@ -4,4 +4,7 @@ class FeeBurden < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -17,4 +17,8 @@ class Prefecture < ActiveHash::Base
     { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
+  
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -20,5 +20,4 @@ class Prefecture < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -8,4 +8,7 @@ class Status < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
+
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
 
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,26 +23,18 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ユーザーによって処理を分岐 %>
     <% if user_signed_in? %>
       <% if current_user.id == @items.user_id %>
         <%= link_to '商品の編集', item_path(@items.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-      <% end %>
-    <% end %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in? %>
-      <% if current_user.id != @items.user_id %>
+      <% else %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <% end %>
     <% end %>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <%# /ユーザーによって処理を分岐 %>
+  <%# 商品の概要 %>
     <div class="item-explain-box">
       <span><%= @items.explanation %></span>
     </div>
@@ -110,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @items.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,9 @@
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -25,7 +25,7 @@
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', item_path(@items.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @items.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @items.image, class:"item-box-img" if @items.image.attached?%>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,54 +16,61 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @items.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @items.fee_burden.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', item_path(@items.id), method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @items.user_id %>
+        <%= link_to '商品の編集', item_path(@items.id), method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% end %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? %>
+      <% if current_user.id != @items.user_id %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @items.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @items.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @items.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @items.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @items.fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @items.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @items.day_required.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
商品詳細表示ページのリンク設定
商品情報の紐付け
ユーザー毎に見ることができる表示を分ける条件分岐の設定

# Why
ログインしている出品者のみが編集、削除をできる様にし、
ログインしている出品者以外が購入することができる様にするため。


# 動作確認動画
・ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/d79e07e51bc5754936d103b278067340

・出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/82353f00c16df8ededf0db3c126eef60

・出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/9528cd68a4fd69d4a036c49724d5f0b5

・商品出品時に登録した情報が見られるようになっていること
・画像が表示されており、画像がリンク切れなどになっていないこと
https://gyazo.com/0c30a81144a60498faf59c4efda7adf8